### PR TITLE
Russellseymour/datafile existence

### DIFF
--- a/cmdlets/internal/Read-DataAsJson.ps1
+++ b/cmdlets/internal/Read-DataAsJson.ps1
@@ -8,26 +8,43 @@ function Read-DataAsJson
         $FileName
     )
 
-    # Ensure that the specified file exists
-    if (!(Test-Path -Path $Filename))
+    # Determine if the FileName is absolute
+    # URLs will return True so this is safe for all tests
+    $is_rooted = Split-Path -Path $FileName -IsAbsolute
+
+    # If the path is not rooted resolve the path
+    # The path has to be absolute for the URI scheme to work
+    if (!$is_rooted)
     {
-        $message = "Data file cannot be found: {0}" -f $FileName
-        throw $message
+        # Attempt to resolve the path
+        $resolved = Resolve-Path -Path $Filename -ErrorAction SilentlyContinue
 
-    } else {
-
-        # Resolve the path so it is an absolute path
-        # This is required to ensure that the URI scheme works properly
-        $Filename = Resolve-Path -Path $Filename
+        # If the filename is empty the file does not exist
+        if ([String]::IsNullOrEmpty($resolved))
+        {
+            $message = "Data file cannot be found: {0}" -f $FileName
+            throw $message
+        } else {
+            $Filename = $resolved
+        }
     }
+
+    # Get the scheme of the file
+    $scheme = ([uri]$Filename).Scheme
 
     # Get the content of the file
     # Select the best operation based on the type of file
-    $scheme = ([uri]$Filename).Scheme
     switch -wildcard ($scheme)
     {
         "file"
         {
+            # Ensure that the specified file exists
+            if (!(Test-Path -Path $Filename))
+            {
+                $message = "Data file cannot be found: {0}" -f $FileName
+                throw $message
+            }
+
             $data = (Get-Content $FileName -Raw) | ConvertFrom-Json
         }
         "http[s]"


### PR DESCRIPTION
The `Read-DataAsJson.ps1` suffered from two issues:

1. Did not check for the existence of the file
2. If the path is relative the  URI scheme does not have a value

The function will now check to see if the path is absolute. For URLs this will return `true`.
Thus for relative filenames the system will attempt to use `Resolve-Path` to get an absolute path.

The absolute path will now give a URI scheme which is used to get the data

/cc @almmechanics 